### PR TITLE
Generalize IO

### DIFF
--- a/network-simple.cabal
+++ b/network-simple.cabal
@@ -35,3 +35,4 @@ library
                    , network (>=2.3 && <2.5)
                    , bytestring (>=0.9.2.1 && <0.11)
                    , transformers (>=0.2 && <0.4)
+                   , exceptions (>=0.3 && <0.4)


### PR DESCRIPTION
While working on `pipes-network` I realized that the end-user code would be much more straightforward if the functions exported by `network-simple` would generalize the `IO` base monad to `MonadIO`, because they wouldn't need to be `liftIO`-ed in order to be used within `Effect'` or `MonadSafe`; they would just work in all cases.

In this patch I go ahead and make that change, and also generalize functions that take `IO` arguments in negative position by using `MonadCatch` from the `exceptions` package (which is not in The Haskell Platform). In `pipes-network` I would still need to provide alternative versions of these functions that protect against premature pipeline termination in case you want to use them with `pipes-safe`.

@Gabriel439, I'd like to know your thoughts on this since you are much more familiar than I am with `MonadIO` and `MonadCatch`. Does this sound good to you? Overall, I think that the API is now more flexible and without introducing noticeable complexity.
