### PR TITLE
Increase upper bounds for `exceptions` dependency

### DIFF
--- a/network-simple.cabal
+++ b/network-simple.cabal
@@ -1,5 +1,5 @@
 name:                network-simple
-version:             0.3.0
+version:             0.3.1
 homepage:            https://github.com/k0001/network-simple
 bug-reports:         https://github.com/k0001/network-simple/issues
 license:             BSD3
@@ -37,4 +37,4 @@ library
                    , bytestring   (>=0.9.2.1 && <0.11)
                    , transformers (>=0.2 && <0.4)
                    -- Packages not in The Haskell Platform
-                   , exceptions   (>=0.3 && <0.4)
+                   , exceptions   (>=0.3 && <0.6)


### PR DESCRIPTION
It seems to be no issue using the lastest version of `exceptions` which is `0.5`.

`network-simple-0.3.1` is already picked by the current version of `pipes-network`, so no need to modify the versions there.
