### PR TITLE
Shutdown socket gracefully. Simplify server cleanup.

### DIFF
--- a/network-simple.cabal
+++ b/network-simple.cabal
@@ -1,5 +1,5 @@
 name:                network-simple
-version:             0.4.0.3
+version:             0.4.0.4
 homepage:            https://github.com/k0001/network-simple
 bug-reports:         https://github.com/k0001/network-simple/issues
 license:             BSD3
@@ -38,4 +38,5 @@ library
                    , bytestring   (>=0.9.2.1 && <0.11)
                    , transformers (>=0.2 && <0.5)
                    -- Packages not in The Haskell Platform
+                   , slave-thread
                    , exceptions   (>=0.6 && <0.9)


### PR DESCRIPTION
This patch add two things:

- shutdown socket before closing
- change custom `forkFinally` with the same function from `SlaveThread` to
   simplify server cleanup on shutdown. Without it user need to develop a custom solution
   for killing incoming connections or they will wait for client disconnections.
