### PR TITLE
Increase upper bound of transformers

### DIFF
--- a/network-simple.cabal
+++ b/network-simple.cabal
@@ -36,6 +36,6 @@ library
   build-depends:     base         (>=4.5 && < 5)
                    , network      (>=2.3 && <2.7)
                    , bytestring   (>=0.9.2.1 && <0.11)
-                   , transformers (>=0.2 && <0.5)
+                   , transformers (>=0.2 && <0.6)
                    -- Packages not in The Haskell Platform
                    , exceptions   (>=0.6 && <0.9)


### PR DESCRIPTION
Since GHC8 comes with transformers-0.5.2.0

This compiles with GHC 8.0.1-rc4.