### PR TITLE
Updated dependencies

### DIFF
--- a/network-simple.cabal
+++ b/network-simple.cabal
@@ -34,8 +34,8 @@ library
   exposed-modules:   Network.Simple.TCP
   other-modules:     Network.Simple.Internal
   build-depends:     base         (>=4.7 && < 5)
-                   , network      (>=3)
-                   , network-bsd  (>=2.8)
+                   , network      (>=2.7)
+                   , network-bsd  (>=2.7)
                    , bytestring
                    , transformers
                    , safe-exceptions

--- a/network-simple.cabal
+++ b/network-simple.cabal
@@ -34,7 +34,8 @@ library
   exposed-modules:   Network.Simple.TCP
   other-modules:     Network.Simple.Internal
   build-depends:     base         (>=4.7 && < 5)
-                   , network      (>=2.3)
+                   , network      (>=3)
+                   , network-bsd  (>=2.8)
                    , bytestring
                    , transformers
                    , safe-exceptions


### PR DESCRIPTION
As stated in their hackage description:
> In network-3.0.0.0 the Network.BSD module was split off into its own package, network-bsd-3.0.0.0.

Therefore, the dependency on `network (>=2.3)` is way too relaxed. This leads to failing builds as just happened to me:
```
$ cabal new-build                  
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - basement-0.0.10 (lib) (requires build)
 - cereal-0.5.8.1 (lib) (requires build)
 - hsc2hs-0.68.4 (exe:hsc2hs) (requires build)
 - transformers-compat-0.6.5 (lib) (requires build)
 - network-3.1.0.0 (lib:network) (requires build)
 - exceptions-0.10.2 (lib) (requires build)
 - socks-0.6.0 (lib) (requires build)
 - safe-exceptions-0.1.7.0 (lib) (requires build)
 - network-simple-0.4.4 (lib) (dependency rebuilt)
Starting     cereal-0.5.8.1 (lib)
Starting     hsc2hs-0.68.4 (exe:hsc2hs)
Starting     transformers-compat-0.6.5 (lib)
Starting     basement-0.0.10 (lib)
Building     cereal-0.5.8.1 (lib)
Building     transformers-compat-0.6.5 (lib)
Building     hsc2hs-0.68.4 (exe:hsc2hs)
Building     basement-0.0.10 (lib)
Installing   transformers-compat-0.6.5 (lib)
Completed    transformers-compat-0.6.5 (lib)
Starting     exceptions-0.10.2 (lib)
Building     exceptions-0.10.2 (lib)
Installing   exceptions-0.10.2 (lib)
Completed    exceptions-0.10.2 (lib)
Starting     safe-exceptions-0.1.7.0 (lib)
Building     safe-exceptions-0.1.7.0 (lib)
Installing   safe-exceptions-0.1.7.0 (lib)
Installing   hsc2hs-0.68.4 (exe:hsc2hs)
Completed    hsc2hs-0.68.4 (exe:hsc2hs)
Starting     network-3.1.0.0 (all, legacy fallback)
Completed    safe-exceptions-0.1.7.0 (lib)
Building     network-3.1.0.0 (all, legacy fallback)
Installing   cereal-0.5.8.1 (lib)
Completed    cereal-0.5.8.1 (lib)
Installing   network-3.1.0.0 (all, legacy fallback)
Completed    network-3.1.0.0 (all, legacy fallback)
Installing   basement-0.0.10 (lib)
Completed    basement-0.0.10 (lib)
Starting     socks-0.6.0 (lib)
Building     socks-0.6.0 (lib)
Installing   socks-0.6.0 (lib)
Completed    socks-0.6.0 (lib)
Preprocessing library for network-simple-0.4.4..
Building library for network-simple-0.4.4..
[1 of 2] Compiling Network.Simple.Internal ( src/Network/Simple/Internal.hs, /home/javier/network-simple/dist-newstyle/build/x86_64-linux/ghc-8.6.5/network-simple-0.4.4/build/Network/Simple/Internal.o )

src/Network/Simple/Internal.hs:24:1: error:
    Could not find module ‘Network.BSD’
    Use -v to see a list of the files searched for.
   |
24 | import qualified Network.BSD as NS (getServicePortNumber)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This PR updates de dependencies to support the package split.

Also, as I'm not a user of Nix, I have no idea if any other changes are required. Maybe add `network-bsd` to `pkg.nix`.